### PR TITLE
Retain MAKEFLAGS

### DIFF
--- a/usr/sys/Makefile
+++ b/usr/sys/Makefile
@@ -2,11 +2,12 @@
 # That's probably not idea.
 all:
 	-killall qemu-system-riscv64
-	make -C sys
-	make -C dev
-	make -C conf
+	make $(MAKEFLAGS) -C sys
+	make $(MAKEFLAGS) -C dev
+	make $(MAKEFLAGS) -C conf
 	# cd conf; make unix allsystems
 
+.PHONY: clean
 clean:
 	make -C dev clean
 	make -C conf clean


### PR DESCRIPTION
- Add preliminary support for slightly different kernels via BOARD. This is the start of landing support for QEMU, K210, BeagleV, Nezha, ESP32C3, and other close members of the family. It may look more polymorphic than #ifdef later.
- Pass MAKEFLAGS to child makes.
