### PR TITLE
Warning/error fixes to src/cmd for building on RISC-V

### DIFF
--- a/tools/user.mk
+++ b/tools/user.mk
@@ -1,4 +1,4 @@
-CFLAGS += -nostdlib  -nostdinc -I../../include
+CFLAGS += -nostdinc -I$(realpath $(ROOT)/../../usr/include)
 LIBC := -nostdlib -L../libc -lc
 LD = $(PREFIX)ld
 STARTUP=../libc/csu/crt0.o

--- a/usr/include/stdio.h
+++ b/usr/include/stdio.h
@@ -1,4 +1,5 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
+#include <stddef.h>
 
 #define	BUFSIZ	512
 #define	_NFILE	20
@@ -46,3 +47,14 @@ char	*fgets();
 int     printf (const char *__restrict, ...);
 int     fprintf (FILE*, const char *__restrict, ...);
 int     sprintf (char*, const char *__restrict, ...);
+
+size_t fread(void *restrict ptr, size_t size, size_t nitems,
+         FILE *restrict stream);
+
+size_t fwrite(const void *restrict ptr, size_t size, size_t nitems,
+         FILE *restrict stream);
+
+int fscanf(FILE *restrict stream, const char *restrict format, ...);
+int scanf(const char *restrict format, ...);
+int sscanf(const char *restrict s, const char *restrict format, ...);
+

--- a/usr/include/string.h
+++ b/usr/include/string.h
@@ -2,6 +2,8 @@
 
 #include <stddef.h>
 
+char * index(const char *s, int c);
+char * rindex(const char *s, int c);
 void *   memchr (const void *, int, long unsigned int);
 int      memcmp (const void *, const void *, long unsigned int);
 void *   memcpy (void *__restrict, const void *__restrict, long unsigned int);

--- a/usr/src/cmd/awk/.gitignore
+++ b/usr/src/cmd/awk/.gitignore
@@ -1,0 +1,2 @@
+# Generated files
+awk.lx.c

--- a/usr/src/cmd/awk/awk.def
+++ b/usr/src/cmd/awk/awk.def
@@ -49,7 +49,8 @@ extern cell	*nfloc;		/* NF */
 
 awkfloat setfval(), getfval();
 char	*setsval(), *getsval();
-char	*tostring(), *tokname(), *malloc();
+char	*tostring(), *tokname();
+void	*malloc();
 double	log(), sqrt(), exp(), atof();
 
 /* function types */

--- a/usr/src/cmd/cmd_common.mk
+++ b/usr/src/cmd/cmd_common.mk
@@ -1,0 +1,4 @@
+#to be used by children Makefiles of cmd/
+
+include "../../../tools/common.mk"
+include "../../../tools/user.mk"

--- a/usr/src/cmd/crypt.c
+++ b/usr/src/cmd/crypt.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #define ECHO 010
 #define ROTORSZ 256

--- a/usr/src/cmd/cu.c
+++ b/usr/src/cmd/cu.c
@@ -1,9 +1,11 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <sgtty.h>
+#include <unistd.h>
 /*
  *	cu telno [-t] [-s speed] [-l line] [-a acu]
  *

--- a/usr/src/cmd/dumpdir.c
+++ b/usr/src/cmd/dumpdir.c
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/param.h>
 #include <sys/inode.h>
 #include <sys/ino.h>
@@ -86,7 +87,7 @@ char *argv[];
 	printem(prebuf, (ino_t) 2);
 	exit(0);
 }
-	i = 0;
+	int i = 0;
 /*
  * Read the tape, bulding up a directory structure for extraction
  * by name
@@ -218,7 +219,7 @@ eloop:
 readtape(b)
 char *b;
 {
-	register i;
+	int i;
 	struct spcl tmpbuf;
 
 	if (bct >= NTREC) {

--- a/usr/src/cmd/eqn/.gitignore
+++ b/usr/src/cmd/eqn/.gitignore
@@ -1,0 +1,4 @@
+# generated files
+e.c
+e.def
+y.tab.h

--- a/usr/src/cmd/find.c
+++ b/usr/src/cmd/find.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/dir.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/usr/src/cmd/getty.c
+++ b/usr/src/cmd/getty.c
@@ -8,6 +8,7 @@
 #include <sgtty.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define ERASE	'#'
 #define KILL	'@'

--- a/usr/src/cmd/init.c
+++ b/usr/src/cmd/init.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <utmp.h>
+#include <unistd.h>
 
 #define	TABSIZ	100
 #define	ALL	p = &itab[0]; p < &itab[TABSIZ]; p++

--- a/usr/src/cmd/ld.c
+++ b/usr/src/cmd/ld.c
@@ -10,8 +10,7 @@
 #include "sys/stat.h"
 
 #include <stdio.h>
-
-extern char *malloc();
+#include <stdlib.h>
 
 union bwl {
 	char b;
@@ -1080,7 +1079,7 @@ char *acp;
 	if(text.size <= 0)
 		return(1);	/* regular archive */
 	mget(&text, (int *)&archdr, sizeof archdr);
-	if(strncmp(archdr.aname, goodnm, 14) != 0)
+	if(strncmp(archdr.aname, goodnm, 14U) != 0)
 		return(1);	/* regular archive */
 	else {
 		fstat(infil, &x);

--- a/usr/src/cmd/login.c
+++ b/usr/src/cmd/login.c
@@ -8,6 +8,8 @@
 #include <sgtty.h>
 #include <utmp.h>
 #include <signal.h>
+#include <string.h>
+#include <unistd.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/usr/src/cmd/mail.c
+++ b/usr/src/cmd/mail.c
@@ -1,13 +1,14 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
+#include <pwd.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pwd.h>
-#include <utmp.h>
-#include <signal.h>
-#include <sys/types.h>
+#include <string.h>
 #include <sys/stat.h>
-#include <setjmp.h>
+#include <sys/types.h>
+#include <utmp.h>
 #include <whoami.h>
 
 /*copylet flags */

--- a/usr/src/cmd/mkfs.c
+++ b/usr/src/cmd/mkfs.c
@@ -13,6 +13,8 @@
 #define	itoo(x)	(int)((x+15)&07)
 #ifndef STANDALONE
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <a.out.h>
 #endif
 #include <sys/param.h>

--- a/usr/src/cmd/mv.c
+++ b/usr/src/cmd/mv.c
@@ -4,13 +4,15 @@
  * mv file1 file2
  */
 
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <unistd.h>
 #include <sys/dir.h>
-#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #define	DOT	"."
 #define	DOTDOT	".."

--- a/usr/src/cmd/neqn/.gitignore
+++ b/usr/src/cmd/neqn/.gitignore
@@ -1,0 +1,4 @@
+# generated files
+e.c
+e.def
+y.tab.h

--- a/usr/src/cmd/newgrp.c
+++ b/usr/src/cmd/newgrp.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <grp.h>
 #include <pwd.h>
 

--- a/usr/src/cmd/osh.c
+++ b/usr/src/cmd/osh.c
@@ -7,6 +7,7 @@
 #include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #undef putc
 #undef getc

--- a/usr/src/cmd/ps.c
+++ b/usr/src/cmd/ps.c
@@ -7,6 +7,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <a.out.h>
 #include <core.h>
@@ -20,7 +21,7 @@ struct nlist nl[] = {
 	{ "_proc" },
 	{ "_swapdev" },
 	{ "_swplo" },
-	{ NULL },
+	{ 0 },
 };
 
 struct	proc mproc;
@@ -33,10 +34,8 @@ int	vflg;
 int	kflg;
 int	xflg;
 char	*tptr;
-long	lseek();
 char	*gettty();
 char	*getptr();
-char	*strncmp();
 int	aflg;
 int	mem;
 int	swmem;
@@ -191,7 +190,7 @@ getdev()
 }
 
 long
-round(a, b)
+my_round(a, b)
 	long		a, b;
 {
 	long		w = ((a+b-1)/b)*b;
@@ -235,7 +234,7 @@ prcom(puid)
 	datsiz = ctob(u.u_dsize);
 	stksiz = ctob(u.u_ssize);
 	septxt = u.u_sep;
-	datmap.b1 = (septxt ? 0 : round(txtsiz,TXTRNDSIZ));
+	datmap.b1 = (septxt ? 0 : my_round(txtsiz,TXTRNDSIZ));
 	datmap.e1 = datmap.b1+datsiz;
 	datmap.f1 = ctob(USIZE)+addr;
 	datmap.b2 = stackbas(stksiz);

--- a/usr/src/cmd/ptx.c
+++ b/usr/src/cmd/ptx.c
@@ -22,6 +22,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <signal.h>
+#include <unistd.h>
+
 #define DEFLTX "/usr/lib/eign"
 #define TILDE 0177
 #define SORT "/bin/sort"

--- a/usr/src/cmd/ranlib.c
+++ b/usr/src/cmd/ranlib.c
@@ -1,10 +1,12 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 
-#include	<ar.h>
-#include	<a.out.h>
-#include	<stdio.h>
+#include <a.out.h>
+#include <ar.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #define	MAGIC	exp.a_magic
 #define	BADMAG	MAGIC!=A_MAGIC1 && MAGIC!=A_MAGIC2  \
 		&& MAGIC!=A_MAGIC3 && MAGIC!=A_MAGIC4

--- a/usr/src/cmd/rm.c
+++ b/usr/src/cmd/rm.c
@@ -4,6 +4,7 @@ int	errcode;
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/dir.h>

--- a/usr/src/cmd/sa.c
+++ b/usr/src/cmd/sa.c
@@ -54,7 +54,7 @@ char **argv;
 {
 	FILE *ff;
 	int i, j, k;
-	extern tcmp(), ncmp(), bcmp();
+	extern tcmp(), ncmp(), my_bcmp();
 	extern float sum();
 	float ft;
 
@@ -202,7 +202,7 @@ char **argv;
 		printmoney();
 		exit(0);
 	}
-	qsort(tab, k, sizeof(tab[0]), nflg? ncmp: (bflg?bcmp:tcmp));
+	qsort(tab, k, sizeof(tab[0]), nflg? ncmp: (bflg?my_bcmp:tcmp));
 	column(ncom, treal, tcpu, tsys);
 	printf("\n");
 	for (i=0; i<k; i++)
@@ -345,7 +345,7 @@ struct tab *p1, *p2;
 	return(p2->count - p1->count);
 }
 
-bcmp(p1, p2)
+my_bcmp(p1, p2)
 struct tab *p1, *p2;
 {
 	float f1, f2;

--- a/usr/src/cmd/strip.c
+++ b/usr/src/cmd/strip.c
@@ -3,6 +3,8 @@
 
 #include <a.out.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 char	*tname;
 char	*mktemp();

--- a/usr/src/cmd/su.c
+++ b/usr/src/cmd/su.c
@@ -1,8 +1,10 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pwd.h>
+#include <string.h>
+#include <unistd.h>
 
 struct	passwd *pwd,*getpwnam();
 char	*crypt();

--- a/usr/src/cmd/tail.c
+++ b/usr/src/cmd/tail.c
@@ -11,10 +11,13 @@
  *	Type 'r' means in lines in reverse order from end
  *	 (for -r, default is entire buffer )
 */
-#include	<sys/types.h>
-#include	<sys/stat.h>
-#include	<errno.h>
+
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #define LBIN 4097
 struct	stat	statb;
 char bin[LBIN];

--- a/usr/src/cmd/tc.c
+++ b/usr/src/cmd/tc.c
@@ -7,6 +7,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define	oput(c) if (pgskip==0) putchar(c); else;
 #define MAXY 3071

--- a/usr/src/cmd/tk.c
+++ b/usr/src/cmd/tk.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define MAXY 3071
 #define LINE 47

--- a/usr/src/cmd/tsort.c
+++ b/usr/src/cmd/tsort.c
@@ -30,7 +30,7 @@ struct predlist {
 	struct nodelist *pred;
 };
 
-struct nodelist *index();
+struct nodelist *my_index();
 struct nodelist *findloop();
 struct nodelist *mark();
 char *empty = "";
@@ -57,8 +57,8 @@ char **argv;
 			break;
 		if(x!=2)
 			error("odd data",empty);
-		i = index(precedes);
-		j = index(follows);
+		i = my_index(precedes);
+		j = my_index(follows);
 		if(i==j||present(i,j))
 			continue;
 		t = (struct predlist *)malloc(sizeof(struct predlist));
@@ -111,7 +111,7 @@ struct nodelist *i;
 /*	turn a string into a node pointer
 */
 struct nodelist *
-index(s)
+my_index(s)
 register char *s;
 {
 	register struct nodelist *i;

--- a/usr/src/cmd/update.c
+++ b/usr/src/cmd/update.c
@@ -15,6 +15,13 @@ char *fillst[] = {
 	0,
 };
 
+void dosync()
+{
+	sync();
+	signal(SIGALRM, dosync);
+	alarm(30);
+}
+
 main()
 {
 	char **f;
@@ -29,11 +36,4 @@ main()
 	dosync();
 	for(;;)
 		pause();
-}
-
-void dosync()
-{
-	sync();
-	signal(SIGALRM, dosync);
-	alarm(30);
 }

--- a/usr/src/cmd/wall.c
+++ b/usr/src/cmd/wall.c
@@ -2,14 +2,14 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <utmp.h>
+
 #define	USERS	50
 
 char	mesg[3000];
 int	msize;
 struct	utmp utmp[USERS];
-char	*strcpy();
-char	*strcat();
 
 main(argc, argv)
 char *argv[];

--- a/usr/src/cmd/write.c
+++ b/usr/src/cmd/write.c
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <signal.h>
+#include <unistd.h>
 #include <utmp.h>
 
 char	*strcat();

--- a/usr/src/libmp/pow.c
+++ b/usr/src/libmp/pow.c
@@ -1,6 +1,7 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 #include <mp.h>
+
 pow(a,b,c,d) MINT *a,*b,*c,*d;
 {	int i,j,n;
 	MINT x,y;

--- a/usr/sys/sys/n200/gd32vf103.h
+++ b/usr/sys/sys/n200/gd32vf103.h
@@ -62,10 +62,7 @@ typedef __UINT64_TYPE__   uint64_t;
 
  /* define value of high speed crystal oscillator (HXTAL) in Hz */
  #if !defined  HXTAL_VALUE  
-   #ifdef GD32VF103R_START
-   #define HXTAL_VALUE    ((uint32_t)25000000) /*!< value of the external oscillator in Hz */
-   #define HXTAL_VALUE_8M  HXTAL_VALUE
-#elif defined(GD32VF103V_EVAL) || defined(GD32VF103C_START) || defined(GD32VF103T_START)
+   #ifdef GD32VF103R_START #define HXTAL_VALUE    ((uint32_t)25000000) /*!< value of the external oscillator in Hz */ #define HXTAL_VALUE_8M  HXTAL_VALUE #elif defined(GD32VF103V_EVAL) || defined(GD32VF103C_START) || defined(GD32VF103T_START)
    #define HXTAL_VALUE    ((uint32_t)8000000) /*!< value of the external oscillator in Hz */
    #define HXTAL_VALUE_25M  HXTAL_VALUE
    #else

--- a/usr/sys/sys/n200/gdv32_led.c
+++ b/usr/sys/sys/n200/gdv32_led.c
@@ -41,14 +41,7 @@ void delay_cycles( uint32_t cyc ) {
   }
 }
 
-Xled_init() {
-    rcu_periph_clock_enable(RCU_GPIOA);
-    rcu_periph_clock_enable(RCU_GPIOC);
-    gpio_init(GPIOC, GPIO_MODE_OUT_PP, GPIO_OSPEED_50MHZ, GPIO_PIN_13);
-    gpio_init(GPIOA, GPIO_MODE_OUT_PP, GPIO_OSPEED_50MHZ, GPIO_PIN_1|GPIO_PIN_2);
-}
-
-// This is probably not fully correct. The LEDs seems to work only the 
+// This is probably not fully correct. The LEDs seems to work only the
 // second time after the device is hard booted.  Might be bad timer.
 // Maybe this code isn't even to blame. {/shrug} RJL 2020-10-12
 led_init()


### PR DESCRIPTION
Mostly mechanical.
A few cases of getting local "index", "round" or similar ANSI-C names out of global space. 